### PR TITLE
skip records with missing alignment information

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -371,6 +371,11 @@ fn main_cmd(path_index: PathIndex, bam_path: PathBuf) -> Result<()> {
             continue;
         };
 
+        // skip the record if there is no alignment information
+        if record.alignment_start().is_none() || record.alignment_end().is_none() {
+            continue;
+        }
+
         let start = record.alignment_start().unwrap();
         let end = record.alignment_end().unwrap();
         let al_len = record.alignment_span();


### PR DESCRIPTION
This avoids this kind of error:

```shell
RUST_BACKTRACE=1 gfainject --gfa chr1-19+XY.ref+pan.p95.gfa --bam 4512-JFI-0347.sub1.bam > 4512-JFI-0347.sub1.gfainject.gaf
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', src/main.rs:375:19
stack backtrace:
```